### PR TITLE
GUI scale tweaks

### DIFF
--- a/game/src/Autoload/GuiScale.gd
+++ b/game/src/Autoload/GuiScale.gd
@@ -1,17 +1,16 @@
 extends Node
 
-#the default value
-const error_guiscale : float = 1
+const error_guiscale : float = -1.0
 
 @export
 var minimum_guiscale : float = 0.1
 
 const _starting_guiscales : Dictionary = {
-	float(0.5): &"0.5x",
+	float(0.5) : &"0.5x",
 	float(0.75): &"0.75x",
-	float(1): &"1x",
-	float(1.5): &"1.5x",
-	float(2): &"2x",
+	float(1)   : &"1x",
+	float(1.5) : &"1.5x",
+	float(2)   : &"2x",
 }
 
 var _guiscales: Dictionary
@@ -31,13 +30,12 @@ func has_guiscale(guiscale_value : float) -> bool:
 func add_guiscale(guiscale_value: float, guiscale_name: StringName=&"") -> bool:
 	if has_guiscale(guiscale_value): return true
 	var scale_dict := { value = guiscale_value }
-	var display_name := "%sx" % [guiscale_value]
 	if not guiscale_name.is_empty():
-		scale_dict.name = guiscale_name
-		#don't need to change the display name
-	scale_dict.display_name = StringName(display_name)
+		scale_dict.display_name = guiscale_name
+	else:
+		scale_dict.display_name = StringName("%sx" % guiscale_value)
 	if guiscale_value < minimum_guiscale:
-		push_error("GUI scale %s is smaller than the minimum %s" % [scale_dict.display_name,minimum_guiscale])
+		push_error("GUI scale %s is smaller than the minimum %s" % [scale_dict.display_name, minimum_guiscale])
 		return false
 	_guiscales[guiscale_value] = scale_dict
 	return true
@@ -62,4 +60,3 @@ func set_guiscale(guiscale:float) -> void:
 	
 func reset_guiscale() -> void:
 	set_guiscale(get_current_guiscale())
-	

--- a/game/src/Autoload/Resolution.gd
+++ b/game/src/Autoload/Resolution.gd
@@ -9,13 +9,13 @@ const _starting_resolutions : Dictionary = {
 	Vector2i(3840,2160): &"4K",
 	Vector2i(2560,1080): &"UW1080p",
 	Vector2i(1920,1080): &"1080p",
-	Vector2i(1366,768): &"",
-	Vector2i(1536,864): &"",
-	Vector2i(1280,720): &"720p",
-	Vector2i(1440,900): &"",
-	Vector2i(1600,900): &"",
-	Vector2i(1024,600): &"",
-	Vector2i(800,600): &""
+	Vector2i(1366,768) : &"",
+	Vector2i(1536,864) : &"",
+	Vector2i(1280,720) : &"720p",
+	Vector2i(1440,900) : &"",
+	Vector2i(1600,900) : &"",
+	Vector2i(1024,600) : &"",
+	Vector2i(800,600)  : &""
 }
 
 var _resolutions : Dictionary

--- a/game/src/OptionMenu/GuiScaleSelector.gd
+++ b/game/src/OptionMenu/GuiScaleSelector.gd
@@ -1,5 +1,9 @@
 extends SettingOptionButton
 
+# REQUIREMENTS
+# * UIFUN-24
+# * UIFUN-31
+
 @export
 var default_value : float = GuiScale.error_guiscale
 
@@ -9,7 +13,7 @@ func _find_guiscale_index_by_value(value : float) -> int:
 			return item_index
 	return -1
 
-func _sync_guiscales(to_select:float=GuiScale.get_current_guiscale()) -> void:
+func _sync_guiscales(to_select : float = GuiScale.get_current_guiscale()) -> void:
 	clear()
 	default_selected = -1
 	selected = -1
@@ -30,12 +34,9 @@ func _sync_guiscales(to_select:float=GuiScale.get_current_guiscale()) -> void:
 		selected = default_selected
 	
 func _setup_button():
-	print("Setup Gui scales Button")
 	if default_value <= 0:
-		#TODO: verify this project setting is what we actually want
-		#print("get default from project settings, default was %f",default_value)
 		default_value = ProjectSettings.get_setting("display/window/stretch/scale")
-	GuiScale.add_guiscale(default_value,&"default")
+	GuiScale.add_guiscale(default_value, &"default")
 	_sync_guiscales()
 
 func _get_value_for_file(select_value : int):
@@ -45,20 +46,18 @@ func _get_value_for_file(select_value : int):
 		return null
 
 func _set_value_from_file(load_value):
-	#no need to match types like resolution does since we don't 
-	#intend on supporting strings
-	var target_guiscale = load_value
-	selected = _find_guiscale_index_by_value(target_guiscale)
-	if selected != -1:return
-	if GuiScale.add_guiscale(target_guiscale):
-		_sync_guiscales(target_guiscale)
-		return
+	if typeof(load_value) == TYPE_FLOAT:
+		var target_guiscale : float = load_value
+		selected = _find_guiscale_index_by_value(target_guiscale)
+		if selected != -1: return
+		if GuiScale.add_guiscale(target_guiscale):
+			_sync_guiscales(target_guiscale)
+			return
 	push_error("Setting value '%s' invalid for setting [%s] %s" % [load_value, section_name, setting_name])
 	selected = default_selected
 
 func _on_item_selected(index:int):
 	if _valid_index(index):
-		print("Change GUI scale on selector index: %d" % index)
 		GuiScale.set_guiscale(get_item_metadata(index))
 	else:
 		push_error("Invalid GuiScaleSelector index: %d" % index)

--- a/game/src/OptionMenu/VideoTab.tscn
+++ b/game/src/OptionMenu/VideoTab.tscn
@@ -48,7 +48,7 @@ layout_mode = 2
 text = "OPTIONS_VIDEO_GUI_SCALE"
 
 [node name="GuiScaleSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
-editor_description = "UI-19"
+editor_description = "UI-23"
 layout_mode = 2
 focus_neighbor_bottom = NodePath("../ScreenModeSelector")
 item_count = 1
@@ -56,6 +56,8 @@ selected = 0
 popup/item_0/text = "MISSING"
 popup/item_0/id = 0
 script = ExtResource("3_pgc5d")
+section_name = "video"
+setting_name = "gui_scale"
 
 [node name="ScreenModeLabel" type="Label" parent="VBoxContainer/GridContainer"]
 editor_description = "UI-44"


### PR DESCRIPTION
- Changed `error_guiscale` to `-1.0`, it's used to mark the default as being unset and needing to be updated with `"display/window/stretch/scale"`, rather than as the default value itself. This is so that the default can be overriden by editing the default export variable without overriding the default value in the project settings.
- Although `_set_value_from_file` doesn't need to support strings, it needs to gracefully fail for invalid inputs (e.g. if someone made a mistake editing the settings file), so some type checking is needed.
- `SettingOptionButton` automatically saves its setting under `section_name/setting_name`, set using export variables. I've set these to `video/gui_scale` for `GuiScaleSelector`.